### PR TITLE
Feat/add and edit subsidiary pages

### DIFF
--- a/apps/frontend/src/App.jsx
+++ b/apps/frontend/src/App.jsx
@@ -12,8 +12,9 @@ import OutProductPage from "./pages/OutProductPage";
 import AddProductPage from "./pages/AddProductPage";
 import EditProductPage from "./pages/EditProductPage";
 import EditUserPage from "./pages/EditUserPage";
-import AddSubsidiaryPage from "./pages/AddSubsidiaryPage";
 import SubsidiariesPage from "./pages/SubsidiariesPage";
+import EditSubsidiaryPage from "./pages/EditSubsidiaryPage";
+import AddSubsidiaryPage from "./pages/AddSubsidiaryPage";
 
 function App() {
   return (
@@ -28,6 +29,7 @@ function App() {
         <Route path="/edit-product/:id" element={<EditProductPage />} />
         <Route path="/branches" element={<SubsidiariesPage />} />
         <Route path="/add-branch" element={<AddSubsidiaryPage />} />
+        <Route path="/edit-branch" element={<EditSubsidiaryPage />} />
         <Route path="/notifications" element={<NotFound />} />
         <Route path="/addUsers" element={<AddUser />} />
         <Route path="/users" element={<UserPage />} />

--- a/apps/frontend/src/App.jsx
+++ b/apps/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import OutProductPage from "./pages/OutProductPage";
 import AddProductPage from "./pages/AddProductPage";
 import EditProductPage from "./pages/EditProductPage";
 import EditUserPage from "./pages/EditUserPage";
+import AddSubsidiaryPage from "./pages/AddSubsidiaryPage";
 
 function App() {
   return (
@@ -25,6 +26,7 @@ function App() {
         <Route path="/add-product" element={<AddProductPage />} />
         <Route path="/edit-product/:id" element={<EditProductPage />} />
         <Route path="/branches" element={<NotFound />} />
+        <Route path="/add-branch" element={<AddSubsidiaryPage />} />
         <Route path="/notifications" element={<NotFound />} />
         <Route path="/addUsers" element={<AddUser />} />
         <Route path="/users" element={<UserPage />} />

--- a/apps/frontend/src/pages/AddSubsidiaryPage.jsx
+++ b/apps/frontend/src/pages/AddSubsidiaryPage.jsx
@@ -1,0 +1,121 @@
+import { Formik, Form } from "formik";
+import * as Yup from "yup";
+import InputField from "../components/InputField";
+import Button from "../components/Button";
+import { MdAdd, MdOutlineCancel } from "react-icons/md";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useUser } from "../hooks/UserUser";
+import { createSubsidiary } from "../services/SubsidiaryService";
+
+const AddSubsidiarySchema = Yup.object().shape({
+  name: Yup.string().required("El nombre de la sucursal es obligatorio"),
+  location: Yup.string().required("La dirección es obligatoria"),
+  type: Yup.string(),
+});
+
+function AddSubsidiaryPage() {
+  const { user } = useUser();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (values) => {
+    try {
+      const subsidiaryData = {
+        location: values.location,
+        name: values.name,
+        type: values.type || "",
+        companyId: user.companyId,
+      };
+  
+      await createSubsidiary(subsidiaryData);
+  
+      toast.success("Sucursal creada correctamente");
+      navigate("/branches");
+    } catch (error) {
+      console.error("Error al crear la sucursal:", error);
+      toast.error("Hubo un error al procesar su solicitud. Por favor, inténtelo de nuevo.");
+    }
+  };
+
+  return (
+    <div 
+      className="flex flex-col items-center bg-green-300 w-full p-14 space-y-16"
+      style={{ height: "calc(100vh - 150px)" }}
+    >
+      <h2 className="text-2xl font-roboto font-bold text-center mb-6">Nueva Sucursal</h2>
+      <Formik
+        initialValues={{
+          name: "",
+          location: "",
+          type: "",
+        }}
+        validationSchema={AddSubsidiarySchema}
+        onSubmit={handleSubmit}
+      >
+        {({ errors, touched }) => (
+          <Form className="flex flex-col gap-2 w-full max-w-lg mx-auto p-6 bg-orange-400">
+            <InputField
+              id="name"
+              label="Nombre"
+              name="name"
+              placeholder="Ingrese el nombre aquí"
+              type="text"
+              isCorrect={!(errors.name && touched.name)}
+              isRequired={true}
+            />
+            {touched.name && errors.name && (
+              <div className="text-red-500 text-sm">{errors.name}</div>
+            )}
+            <InputField
+              id="location"
+              label="Dirección"
+              name="location"
+              placeholder="Ingrese la direción aquí"
+              type="text"
+              isCorrect={!(errors.location && touched.location)}
+              isRequired={true}
+            />
+            {touched.location && errors.location && (
+              <div className="text-red-500 text-sm">{errors.location}</div>
+            )}
+            <InputField
+              id="type"
+              label="Tipo"
+              name="type"
+              placeholder="Ingrese el tipo aquí"
+              type="text"
+              isCorrect={!(errors.type && touched.type)}
+              isRequired={false}
+            />
+            {touched.type && errors.type && (
+              <div className="text-red-500 text-sm">{errors.type}</div>
+            )}
+
+            <div className="flex justify-center gap-4 mt-4">
+              <Button
+                isSubmit
+                type="common"
+                className="bg-[#16a34a] font-roboto font-medium text-xl text-white rounded-xl px-6 py-2 flex items-center gap-2"
+              >
+                Agregar
+                <MdAdd size={19} />
+              </Button>
+              <Button
+                type="common"
+                className="bg-red-600 font-roboto font-medium text-xl text-white rounded-xl px-6 py-2 flex items-center gap-2"
+                onClick={() => {
+                  navigate("/branches");
+                }}
+              >
+                Cancelar
+                <MdOutlineCancel size={19} />
+              </Button>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </div>
+  );
+}
+
+export default AddSubsidiaryPage;

--- a/apps/frontend/src/pages/SubsidiariesPage.jsx
+++ b/apps/frontend/src/pages/SubsidiariesPage.jsx
@@ -71,6 +71,14 @@ export default function SubsidiariesPage() {
     }
   };
 
+  const handleEdit = (subsidiaryId) => {
+    navigate('/edit-branch', {
+      state: {
+        subsidiaryId: subsidiaryId,
+      }
+    });
+  };
+
   const handleDeleteClick = (subsidiaryId) => {
     setSubsidiaryToDelete(subsidiaryId);
     setIsModalVisible(true);
@@ -128,9 +136,12 @@ export default function SubsidiariesPage() {
                 user.UserRol === "Propietario" ? "" : "hidden"
               } hover:bg-neutral-300 font-roboto font-bold text-sm text-neutral-950 rounded-xl pl-4 pr-4 py-2 flex items-center gap-2`}
               type={"common"}
+              onClick={() => {
+                navigate("/add-branch");
+              }}
             >
-              <MdAdd size={19} />
-            </Button>
+            <MdAdd size={19} />
+          </Button>
           ) : (
             <div className="w-0 bg-orange-400"></div>
           )}
@@ -147,6 +158,9 @@ export default function SubsidiariesPage() {
                 "bg-neutral-200 hover:bg-neutral-300 font-roboto font-bold text-sm text-neutral-950 rounded-xl pl-4 pr-4 py-2 flex items-center gap-2"
               }
               type={"common"}
+              onClick={() => {
+                navigate("/add-branch");
+              }}
             >
               <MdAdd size={19} />
             </Button>
@@ -159,10 +173,11 @@ export default function SubsidiariesPage() {
         {filteredSubsidiaries.map((sub, index) => (
           <SubsidiaryItem
             key={index}
-            name={sub.name || "Unknown subsidiary"}
-            location={sub.location || "Unknown location"}
+            name={sub.name || "Sucursal desconocida"}
+            location={sub.location || "Ubicación desconocida"}
             admin={user.UserRol === "Propietario"}
-            type={sub.type || "Unknown type"}
+            type={sub.type || "Tipo desconocido"}
+            onEdit={() => handleEdit(sub.subsidiaryId)}
             onDelete={() => handleDeleteClick(sub.subsidiaryId)}
             onClick={() => setUserSubsidiary(sub.subsidiaryId)}
           />

--- a/apps/frontend/src/services/SubsidiaryService.js
+++ b/apps/frontend/src/services/SubsidiaryService.js
@@ -1,0 +1,27 @@
+import axios from "axios";
+
+export const subsidiaryAPI = axios.create({
+  baseURL: "http://localhost:8000/products",
+});
+
+export async function createSubsidiary(subsidiaryData) {
+  try {
+    const response = await subsidiaryAPI.post("/Subsidiary", subsidiaryData);
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      error.response?.data?.message || "Error al crear la sucursal"
+    );
+  }
+}
+
+export async function updateSubsidiary(subsidiaryData) {
+  try {
+    const response = await subsidiaryAPI.put(`/Subsidiary`, subsidiaryData);
+    return response.data;
+  } catch (error) {
+    throw new Error(
+      error.response?.data?.message || "Error al actualizar la sucursal"
+    );
+  }
+}


### PR DESCRIPTION
In this PR I am implementing the pages to add and edit a subsidiary:

How to test (As owner):

- Run the project on the infrastructure with docker compose up --build.
- Go to localhost:5173
- Login to the website
- Click on the button showing the subsidiary you are currently in.
- On the page where the subsidiaries are displayed press the add button. 
- Add a subsidiary by filling out the form.
- The list of subsidiaries should be updated showing now the new subsidiary.
- On the subsidiary you want to edit click the button with the pencil icon.
- The pre-filled form fields should be displayed with the current data, edit the desired fields and click on the save button.
- The data of the edited subsidiary should be up to date list of subsidiaries.